### PR TITLE
Add Extension and Spell Check Dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,6 @@ The Code Spell Checker extension will, by default, flag lorem ipsum text as bein
 6. Click the OK button to add it. You should now see it listed as a dictionary.
 7. Close the Settings tab.
 
+![lorem-ipsum dictionary within the list of used dictionaries in the settings](https://user-images.githubusercontent.com/25446111/123177639-7faa7000-d43a-11eb-9e4e-97f2897d2060.png)
+
 Any lorem ipsum text within your HTML documents should now be recognized.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This pack contains the following extensions:
 * [Lorem Ipsum](https://marketplace.visualstudio.com/items?itemName=Tyriar.lorem-ipsum) | by Daniel Imms
 * [Preview on Web Server](https://marketplace.visualstudio.com/items?itemName=yuichinukiyama.vscode-preview-server) | by YuichiNukiyama
 * [Web Accessibility](https://marketplace.visualstudio.com/items?itemName=MaxvanderSchee.web-accessibility) | by Max van der Schee
+* [W3C Web Validator](https://marketplace.visualstudio.com/items?itemName=CelianRiboulet.webvalidator) | by Celian Riboulet
 
 ## Lorem Ipsum Dictionary
 The Code Spell Checker extension will, by default, flag lorem ipsum text as being spelled incorrectly because it does not recognize the words. However, you can add in a lorem ipsum dictionary to the extension so the lorem ipsum text is not flagged as being incorrect. This can help to simplify the error messages to those words that are actually misspelled. To add the dictionary (after the extension has been installed):

--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ This pack contains the following extensions:
 * [Lorem Ipsum](https://marketplace.visualstudio.com/items?itemName=Tyriar.lorem-ipsum) | by Daniel Imms
 * [Preview on Web Server](https://marketplace.visualstudio.com/items?itemName=yuichinukiyama.vscode-preview-server) | by YuichiNukiyama
 * [Web Accessibility](https://marketplace.visualstudio.com/items?itemName=MaxvanderSchee.web-accessibility) | by Max van der Schee
+
+## Lorem Ipsum Dictionary
+The Code Spell Checker extension will, by default, flag lorem ipsum text as being spelled incorrectly because it does not recognize the words. However, you can add in a lorem ipsum dictionary to the extension so the lorem ipsum text is not flagged as being incorrect. This can help to simplify the error messages to those words that are actually misspelled. To add the dictionary (after the extension has been installed):
+1. Open the VS Code Settings (Under the File menu, Preferences option).
+2. Search for "c spell dictionary" in the search box without quotes.
+3. Find the _C Spell: Dictionary_ heading in the list of settings.
+4. Click the _Add item_ button.
+5. Type in _lorem-ipsum_.
+6. Click the OK button to add it. You should now see it listed as a dictionary.
+7. Close the Settings tab.
+
+Any lorem ipsum text within your HTML documents should now be recognized.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "streetsidesoftware.code-spell-checker",
     "Tyriar.lorem-ipsum",
     "yuichinukiyama.vscode-preview-server",
-    "maxvanderschee.web-accessibility"
+    "maxvanderschee.web-accessibility",
+    "celianriboulet.webvalidator"
   ]
 }


### PR DESCRIPTION
Based upon feedback from instructors, the following has been done
- Directions to add the lorem ipsum dictionary for the spell check extension has been added so it does not flag that type of text as being misspelled.
- Added a new extension for W3C validation.

Still to be done:
- [ ] Update the changelog