### PR TITLE
Remove HTMLHint Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the "web-development-student-pack" extension pack will be documented in this file.
 
+## [1.0.4] - 2021-08-04
+- Removed the HTMLHint extension due to feature duplication found in W3C Validation extension.
+
 ## [1.0.3] - 2021-07-14
 - Added directions for Lorem Ipsum dictionary for spell checking extension
 - Added web validator extension

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This extension pack is for students taking web development courses at Rio Salado
 This pack contains the following extensions:
 
 * [GitHub Pull Requests and Issues](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) | By GitHub
-* [HTMLHint](https://marketplace.visualstudio.com/items?itemName=mkaufman.HTMLHint) | by Mike Kaufman
 * [HTML CSS Support](https://marketplace.visualstudio.com/items?itemName=ecmel.vscode-html-css) | by ecmel
 * [CSSTree validator](https://marketplace.visualstudio.com/items?itemName=smelukov.vscode-csstree) | by Sergey Melyukov
 * [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) | by Street Side Software

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "icon": "icons/codeGearIcon256.png",
   "displayName": "Web Development Student Extension Pack",
   "description": "An extension pack for students taking web development courses at Rio Salado College.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publisher": "RioSaladoCollegeMedia",
   "author": {
     "name": "Gordon Inman"
@@ -23,7 +23,6 @@
   "extensionPack": [
     "ecmel.vscode-html-css",
     "GitHub.vscode-pull-request-github",
-    "mkaufman.HTMLHint",
     "smelukov.vscode-csstree",
     "streetsidesoftware.code-spell-checker",
     "Tyriar.lorem-ipsum",


### PR DESCRIPTION
Due to some student confusion in error messages they were seeing, we want to remove the HTMLHint extension because it doesn't offer anything beyond the W3C Validation extension. Having both was confusing some students since it was flagging the same issue differently.

- Updated changelog
- Update package file
- Updated readme file

I also noticed that the store has not been updated to v1.0.3 so students are not seeing those changes. It still shows as being on v1.0.2. So, we need to make sure that the extension gets packaged and updated correctly within the store.